### PR TITLE
Fix cms folder path

### DIFF
--- a/element/html.md
+++ b/element/html.md
@@ -1,4 +1,0 @@
----
-title: html
----
-html element

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -6,7 +6,7 @@ public_folder: assets
 collections:
   - name: element
     label: Element
-    folder: element
+    folder: src/pages/element
     create: true
     fields:
       - { name: title, label: Title }


### PR DESCRIPTION
## Summary

Netlify CMS で作成した記事を保存するディレクリを変更しました。
`src` ディレクリ以下にファイルがないと Gatsby のビルド対象にならないためです。

また、Netlify CMS で作成した記事を GitHub に保存できるようにするために、Netlify で Git Gateway の設定をしました。
https://docs.netlify.com/visitor-access/git-gateway/

## TODO

- [x] Change Netlify CMS directory
- [x] Connect Git Gateway 

## Supplement

## Operation Verification
Netlify の deploy preview から HTML 要素の記事を追加して、GitHub に追加されることを確認しました。
https://github.com/shgtkshruch/html/blob/master/src/pages/element/html.md
