### PR TITLE
Styling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 module.exports = {
   siteMetadata: {
-    title: `Gatsby Default Starter`,
-    description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
-    author: `@gatsbyjs`,
+    title: `Interactive HTML reference`,
+    description: `Interactive HTML reference`,
+    author: `@shgtkshruch`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "html",
   "private": true,
-  "description": "A simple starter to get up and developing quickly with Gatsby",
+  "description": "Interactive HTML reference",
   "version": "0.1.0",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "author": "Shigetaka Shirouchi <shgtk.shruch@gmail.com>",
   "dependencies": {
     "gatsby": "^2.18.12",
     "gatsby-image": "^2.2.34",

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -7,25 +7,15 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import { useStaticQuery, graphql } from "gatsby"
 
 import Header from "./header"
 import "./layout.css"
 
-const Layout = ({ children }) => {
-  const data = useStaticQuery(graphql`
-    query SiteTitleQuery {
-      site {
-        siteMetadata {
-          title
-        }
-      }
-    }
-  `)
+const Layout = ({ title, children }) => {
 
   return (
     <>
-      <Header siteTitle={data.site.siteMetadata.title} />
+      <Header siteTitle={ title } />
       <div
         style={{
           margin: `0 auto`,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,21 +1,36 @@
 import React from "react"
 import { Link } from "gatsby"
 
+import { useStaticQuery, graphql } from "gatsby"
+
+
 import Layout from "../components/layout"
 import Image from "../components/image"
 import SEO from "../components/seo"
 
-const IndexPage = () => (
-  <Layout>
-    <SEO title="Home" />
-    <h1>Hi people</h1>
-    <p>Welcome to your new Gatsby site.</p>
-    <p>Now go build something great.</p>
-    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-      <Image />
-    </div>
-    <Link to="/page-2/">Go to page 2</Link>
-  </Layout>
-)
+const IndexPage = () => {
+  const data = useStaticQuery(graphql`
+    query SiteTitleQuery {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  `)
+
+  return (
+    <Layout title={ data.site.siteMetadata.title }>
+      <SEO title="Home" />
+      <h1>Hi people</h1>
+      <p>Welcome to your new Gatsby site.</p>
+      <p>Now go build something great.</p>
+      <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
+        <Image />
+      </div>
+      <Link to="/page-2/">Go to page 2</Link>
+    </Layout>
+  )
+}
 
 export default IndexPage

--- a/src/templates/element.js
+++ b/src/templates/element.js
@@ -2,12 +2,14 @@ import React from "react"
 import { graphql } from "gatsby"
 
 import Layout from "../components/layout"
+import SEO from "../components/seo"
 
 export default function ({ data }) {
   const { markdownRemark } = data
   const { frontmatter, html } = markdownRemark
   return (
     <Layout title={ frontmatter.title }>
+      <SEO title={ frontmatter.title } />
       <div className="blog-post">
         <div
           className="blog-post-content"

--- a/src/templates/element.js
+++ b/src/templates/element.js
@@ -1,17 +1,20 @@
 import React from "react"
 import { graphql } from "gatsby"
 
+import Layout from "../components/layout"
+
 export default function ({ data }) {
   const { markdownRemark } = data
   const { frontmatter, html } = markdownRemark
   return (
-    <div className="blog-post">
-      <h1>{frontmatter.title}</h1>
-      <div
-        className="blog-post-content"
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
-    </div>
+    <Layout title={ frontmatter.title }>
+      <div className="blog-post">
+        <div
+          className="blog-post-content"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </div>
+    </Layout>
   )
 }
 


### PR DESCRIPTION
## Summary

Element ページに Gatsby のデフォルトスタイルが当たるようにしました。
また、Site のタイトルや package.json の name や author を変更しました。

## TODO

- [x] Modify package.json metadata
- [x] Modify site metadata
- [x] Include `Layout` component to element page template
- [x] Add meta data to `<head>` to element page

## Supplement

## Operation Verification
トップページ、element ページにそれぞれスタイルとタイトルがあたっていること。

- Top Page: https://deploy-preview-6--html-shgtkshruch.netlify.com/
- Element Page: https://deploy-preview-6--html-shgtkshruch.netlify.com/element/html
