### PR TITLE
Add content categories to element pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,6 +11,7 @@ exports.createPages = async ({ actions, graphql }) => {
             id
             frontmatter {
               title
+              contentCategories
             }
           }
         }

--- a/src/pages/element/body.md
+++ b/src/pages/element/body.md
@@ -1,5 +1,6 @@
 ---
 title: body
+contentCategories: [sectioningRoot]
 ---
 # Body
 

--- a/src/pages/element/html.md
+++ b/src/pages/element/html.md
@@ -1,5 +1,6 @@
 ---
 title: html
+contentCategories: [none]
 ---
 # HTML
 

--- a/src/templates/element.js
+++ b/src/templates/element.js
@@ -11,6 +11,12 @@ export default function ({ data }) {
     <Layout title={ frontmatter.title }>
       <SEO title={ frontmatter.title } />
       <div className="blog-post">
+        <h2>Content Categories</h2>
+        <ul>
+          {frontmatter.contentCategories.map(category => {
+            return (<li>{category}</li>)
+          })}
+        </ul>
         <div
           className="blog-post-content"
           dangerouslySetInnerHTML={{ __html: html }}
@@ -26,6 +32,7 @@ export const pageQuery = graphql`
       html
       frontmatter {
         title
+        contentCategories
       }
     }
   }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -9,5 +9,47 @@ collections:
     folder: src/pages/element
     create: true
     fields:
-      - { name: title, label: Title }
-      - { name: body, label: Body, widget: markdown }
+      - name: title
+        label: Title
+      - name: contentCategories
+        label: Content Categories
+        widget: select
+        multiple: true
+        options:
+          - label: Metadata content
+            value: metadataContent
+          - label: Flow content
+            value: flowContent
+          - label: Sectioning content
+            value: sectioningContent
+          - label: Heading content
+            value: headingContent
+          - label: Phrasing content
+            value: phrasingContent
+          - label: Embedded content
+            value: embeddedContent
+          - label: Interactive content
+            value: interactiveContent
+          - label: Sectioning root
+            value: sectiongRoot
+          - label: Form-associated content
+            value: formAssociatedContent
+          - label: Listed Element
+            value: listedElement
+          - label: Submittable Element
+            value: submittableElement
+          - label: Resettable Element
+            value: resettableElement
+          - label: Autocapitalize-inheriting element
+            value: autocapitalizeInheritingElement
+          - label: Labelable element
+            value: labelableElement
+          - label: Palpable content
+            value: palpableContent
+          - label: Script-supporting element
+            value: scriptSupportingElement
+          - label: None
+            value: none
+      - name: body
+        label: Body
+        widget: markdown


### PR DESCRIPTION
## Summary

HTML  要素の Content Categories を設定できるようにしました。
Content Categories は Whatwg の仕様書をもとにしました。
https://html.spec.whatwg.org/multipage/indices.html#element-content-categories

Netlify CMS の入力フォームは、Widget 機能で予め用意した選択肢から複数選択可能な select を使いました。
https://www.netlifycms.org/docs/widgets/#select

## TODO

- [x] Enable add content categories from Netlify CMS
- [x] Render content categories to element pages

## Supplement

## Operation Verification
以下のデプロイプレビューで、Content Categories が表示されていること。

- https://5e0c665decfc7e0008388648--html-shgtkshruch.netlify.com/element/html
- https://5e0c665decfc7e0008388648--html-shgtkshruch.netlify.com/element/body