### PR TITLE
Add element list page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -22,6 +22,11 @@ exports.createPages = async ({ actions, graphql }) => {
     console.error(result.errors)
   }
 
+  createPage({
+    path: path.join('element/index'),
+    component: path.resolve(__dirname,"./src/pages/element/index.js")
+  })
+
   result.data.allMarkdownRemark.edges.forEach(({ node }) => {
     createPage({
       path: path.join('element', node.frontmatter.title),

--- a/src/pages/element/body.md
+++ b/src/pages/element/body.md
@@ -1,7 +1,7 @@
 ---
 title: body
 order: 2
-contentCategories: [sectioningRoot]
+contentCategories: [Sectioning root]
 ---
 # Body
 

--- a/src/pages/element/body.md
+++ b/src/pages/element/body.md
@@ -1,5 +1,6 @@
 ---
 title: body
+order: 2
 contentCategories: [sectioningRoot]
 ---
 # Body

--- a/src/pages/element/html.md
+++ b/src/pages/element/html.md
@@ -1,5 +1,6 @@
 ---
 title: html
+order: 1
 contentCategories: [none]
 ---
 # HTML

--- a/src/pages/element/html.md
+++ b/src/pages/element/html.md
@@ -1,7 +1,7 @@
 ---
 title: html
 order: 1
-contentCategories: [none]
+contentCategories: [None]
 ---
 # HTML
 

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -16,7 +16,7 @@ class ElementList extends React.Component {
           {posts.map(({ node:post }, i) => {
             return (
               <li key={i}>
-                <Link to={`element/${post.frontmatter.title}`}>
+                <Link to={`/element/${post.frontmatter.title}/`}>
                   {post.frontmatter.title}
                 </Link>
                 {post.frontmatter.contentCategories.map((category, j) => {

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -13,15 +13,15 @@ class ElementList extends React.Component {
       <Layout title="Element index">
         <SEO title="Element index" />
         <ul>
-          {posts.map(({ node:post }) => {
+          {posts.map(({ node:post }, i) => {
             return (
-              <li>
+              <li key={i}>
                 <Link to={`element/${post.frontmatter.title}`}>
                   {post.frontmatter.title}
                 </Link>
-                {post.frontmatter.contentCategories.map(category => {
+                {post.frontmatter.contentCategories.map((category, j) => {
                   return (
-                    <span style={{ paddingLeft: `10px` }}>[{category}]</span>
+                    <span key={j} style={{ paddingLeft: `10px` }}>[{category}]</span>
                   )
                 })}
               </li>
@@ -32,7 +32,6 @@ class ElementList extends React.Component {
     )
   }
 }
-
 
 export default () => (
   <StaticQuery

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -1,0 +1,50 @@
+import React from "react"
+
+import { Link, StaticQuery, graphql } from "gatsby"
+import Layout from "../../components/layout"
+import SEO from "../../components/seo"
+
+class ElementList extends React.Component {
+  render() {
+    const { data } = this.props
+    const { edges: posts } = data.allMarkdownRemark
+
+    return (
+      <Layout title="Element index">
+        <SEO title="Element index" />
+        <ul>
+          {posts.map(({ node:post }) => {
+            return (
+              <li>
+                <Link to={`element/${post.frontmatter.title}`}>
+                  {post.frontmatter.title}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </Layout>
+    )
+  }
+}
+
+
+export default () => (
+  <StaticQuery
+    query={graphql`
+      {
+        allMarkdownRemark {
+          edges {
+            node {
+              frontmatter {
+                title
+              }
+            }
+          }
+        }
+      }
+    `}
+    render={data => <ElementList data={data} />}
+  />
+)
+

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -19,6 +19,11 @@ class ElementList extends React.Component {
                 <Link to={`element/${post.frontmatter.title}`}>
                   {post.frontmatter.title}
                 </Link>
+                {post.frontmatter.contentCategories.map(category => {
+                  return (
+                    <span style={{ paddingLeft: `10px` }}>[{category}]</span>
+                  )
+                })}
               </li>
             )
           })}
@@ -38,6 +43,7 @@ export default () => (
             node {
               frontmatter {
                 title
+                contentCategories
               }
             }
           }

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -38,11 +38,12 @@ export default () => (
   <StaticQuery
     query={graphql`
       {
-        allMarkdownRemark {
+        allMarkdownRemark(sort: {fields: frontmatter___order, order: ASC}) {
           edges {
             node {
               frontmatter {
                 title
+                order
                 contentCategories
               }
             }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,9 +3,7 @@ import { Link } from "gatsby"
 
 import { useStaticQuery, graphql } from "gatsby"
 
-
 import Layout from "../components/layout"
-import Image from "../components/image"
 import SEO from "../components/seo"
 
 const IndexPage = () => {
@@ -22,13 +20,8 @@ const IndexPage = () => {
   return (
     <Layout title={ data.site.siteMetadata.title }>
       <SEO title="Home" />
-      <h1>Hi people</h1>
-      <p>Welcome to your new Gatsby site.</p>
-      <p>Now go build something great.</p>
-      <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-        <Image />
-      </div>
-      <Link to="/page-2/">Go to page 2</Link>
+      <h1>HTML Element List</h1>
+      <Link to="/element/">Element List</Link>
     </Layout>
   )
 }

--- a/src/templates/element.js
+++ b/src/templates/element.js
@@ -13,8 +13,8 @@ export default function ({ data }) {
       <div className="blog-post">
         <h2>Content Categories</h2>
         <ul>
-          {frontmatter.contentCategories.map(category => {
-            return (<li>{category}</li>)
+          {frontmatter.contentCategories.map((category, i) => {
+            return (<li key={i}>{category}</li>)
           })}
         </ul>
         <div

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,5 +1,6 @@
 backend:
-  name: git-gateway
+  # name: git-gateway
+  name: test-repo
   branch: master
 media_folder: static/assets
 public_folder: assets
@@ -31,7 +32,7 @@ collections:
           - label: Interactive content
             value: interactiveContent
           - label: Sectioning root
-            value: sectiongRoot
+            value: sectioningRoot
           - label: Form-associated content
             value: formAssociatedContent
           - label: Listed Element

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,5 @@
 backend:
-  # name: git-gateway
-  name: test-repo
+  name: git-gateway
   branch: master
 media_folder: static/assets
 public_folder: assets

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -12,6 +12,11 @@ collections:
     fields:
       - name: title
         label: Title
+      - name: order
+        label: Order
+        widget: number
+        valueType: int
+        step: 1
       - name: contentCategories
         label: Content Categories
         widget: select

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -23,39 +23,39 @@ collections:
         multiple: true
         options:
           - label: Metadata content
-            value: metadataContent
+            value: Metadata content
           - label: Flow content
-            value: flowContent
+            value: Flow content
           - label: Sectioning content
-            value: sectioningContent
+            value: Sectioning content
           - label: Heading content
-            value: headingContent
+            value: Heading content
           - label: Phrasing content
-            value: phrasingContent
+            value: Phrasing content
           - label: Embedded content
-            value: embeddedContent
+            value: Embedded content
           - label: Interactive content
-            value: interactiveContent
+            value: Interactive content
           - label: Sectioning root
-            value: sectioningRoot
+            value: Sectioning root
           - label: Form-associated content
-            value: formAssociatedContent
-          - label: Listed Element
-            value: listedElement
+            value: Form-associated content
+          - label: Listed element
+            value: Listed element
           - label: Submittable Element
-            value: submittableElement
-          - label: Resettable Element
-            value: resettableElement
+            value: Submittable element
+          - label: Resettable element
+            value: Resettable element
           - label: Autocapitalize-inheriting element
-            value: autocapitalizeInheritingElement
+            value: Autocapitalize-inheriting element
           - label: Labelable element
-            value: labelableElement
+            value: Labelable element
           - label: Palpable content
-            value: palpableContent
+            value: Palpable content
           - label: Script-supporting element
-            value: scriptSupportingElement
+            value: Script-supporting element
           - label: None
-            value: none
+            value: None
       - name: body
         label: Body
         widget: markdown


### PR DESCRIPTION
## Summary

HTML 要素を一覧表示するページを追加しました。

## TODO

- [x] Add element list page
- [x] Modify content categories name
- [x] Add link of element page list to top page

## Supplement

## Operation Verification
以下の URL にアクセスして、HTML 要素の一覧ページが表示されること。
（html と body 要素の簡易的なページだけ追加しています）

https://5e0c962ff0016300080aac92--html-shgtkshruch.netlify.com/element/
