### PR TITLE
Search element by tag name

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,12 +48,9 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-fonts`,
       options: {
-        fonts: [
-          `Noto Sans JP`,
-          `Noto Serif`,
-        ],
-        display: 'swap'
-      }
-    }
+        fonts: [`Noto Sans JP`, `Noto Serif`],
+        display: "swap",
+      },
+    },
   ],
 }

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -17,7 +17,7 @@ const Heading = styled.h2`
   font-weight: normal;
   font-style: italic;
   font-size: 1rem;
-  font-family: 'Noto Sans JP', sans-serif;
+  font-family: "Noto Sans JP", sans-serif;
   letter-spacing: 0.08em;
   color: ${blue};
 

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -48,6 +48,7 @@ export default class Page extends React.Component {
       currentPosts: [],
       contentCategories: [],
       selectedCategories: [],
+      searchText: 'bb',
     }
 
     this.clickCategory = this.clickCategory.bind(this)
@@ -73,7 +74,7 @@ export default class Page extends React.Component {
       )
     })
 
-    this.setState({ selectedCategories, currentPosts })
+    this.setState({ selectedCategories, currentPosts, searchText: '' })
   }
 
   search(value) {
@@ -81,7 +82,7 @@ export default class Page extends React.Component {
       return post.frontmatter.title.indexOf(value) > -1
     })
 
-    this.setState({ currentPosts })
+    this.setState({ currentPosts, searchText: value })
   }
 
   isHidden(category) {
@@ -125,7 +126,10 @@ export default class Page extends React.Component {
               )
             })}
           </Ul>
-          <SearchForm onInput={value => this.search(value)} />
+          <SearchForm
+            value={this.state.searchText}
+            onInput={value => this.search(value)}
+          />
         </Container>
 
         <Container>

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -5,6 +5,7 @@ import Layout from "../layout"
 import SEO from "../seo"
 import Button from "../button"
 import Elements from "../elements"
+import SearchForm from "./search-form"
 
 const blue = `#1d2652`
 
@@ -64,7 +65,23 @@ export default class Page extends React.Component {
       selectedCategories = [...this.state.selectedCategories, category]
     }
 
-    this.setState({ selectedCategories })
+    const currentPosts = this.state.posts.filter(post => {
+      return (
+        post.frontmatter.contentCategories.filter(cat =>
+          selectedCategories.includes(cat)
+        ).length === selectedCategories.length
+      )
+    })
+
+    this.setState({ selectedCategories, currentPosts })
+  }
+
+  search(value) {
+    const currentPosts = this.state.posts.filter(post => {
+      return post.frontmatter.title.indexOf(value) > -1
+    })
+
+    this.setState({ currentPosts })
   }
 
   isHidden(category) {
@@ -83,21 +100,7 @@ export default class Page extends React.Component {
   componentDidMount() {
     const { posts, contentCategories } = this.props
 
-    this.setState({ posts, contentCategories })
-  }
-
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    const currentPosts = this.state.posts.filter(post => {
-      return (
-        post.frontmatter.contentCategories.filter(cat =>
-          this.state.selectedCategories.includes(cat)
-        ).length === this.state.selectedCategories.length
-      )
-    })
-
-    if (currentPosts.length === this.state.currentPosts.length) return false
-
-    this.setState({ currentPosts })
+    this.setState({ posts, contentCategories, currentPosts: posts })
   }
 
   render() {
@@ -122,6 +125,7 @@ export default class Page extends React.Component {
               )
             })}
           </Ul>
+          <SearchForm onInput={value => this.search(value)} />
         </Container>
 
         <Container>

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -10,11 +10,27 @@ import SearchForm from "./search-form"
 const blue = `#1d2652`
 
 const Container = styled.div`
-  margin: 0 0 3rem;
-  padding: 1.4em;
+  position: relative;
+  margin: 0 0 2rem;
+  padding: 1.8em 1.4em 1.4em;
   border: 1px dashed ${blue};
 `
 const Heading = styled.h2`
+  position: absolute;
+  top: -0.5em;
+  left: 1em;
+  margin: 0;
+  padding: 0 1em;
+  background-color: #fff;
+  font-weight: normal;
+  font-style: italic;
+  font-size: 1rem;
+  font-family: "Noto Sans JP", sans-serif;
+  letter-spacing: 0.08em;
+  color: ${blue};
+`
+
+const _h = styled.h2`
   font-weight: normal;
   font-style: italic;
   font-size: 1rem;

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -80,14 +80,13 @@ export default class Page extends React.Component {
     return !currentPostsContentCategories.includes(category)
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
+  componentDidMount() {
     const { posts, contentCategories } = this.props
 
-    if (this.state.posts.length === 0) {
-      this.setState({ posts, contentCategories })
-      return
-    }
+    this.setState({ posts, contentCategories })
+  }
 
+  componentDidUpdate(prevProps, prevState, snapshot) {
     const currentPosts = this.state.posts.filter(post => {
       return (
         post.frontmatter.contentCategories.filter(cat =>

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -1,0 +1,140 @@
+import React from "react"
+import styled from "@emotion/styled"
+
+import Layout from "../layout"
+import SEO from "../seo"
+import Button from "../button"
+import Elements from "../elements"
+
+const blue = `#1d2652`
+
+const Container = styled.div`
+  margin: 0 0 3rem;
+  padding: 1.4em;
+  border: 1px dashed ${blue};
+`
+const Heading = styled.h2`
+  font-weight: normal;
+  font-style: italic;
+  font-size: 1rem;
+  font-family: 'Noto Sans JP', sans-serif;
+  letter-spacing: 0.08em;
+  color: ${blue};
+
+  &::before {
+    content: "-";
+    padding-right: 0.2em;
+  }
+`
+
+const Ul = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  list-style-type: none;
+  margin: 0 0 -0.6em;
+
+  li {
+    margin-right: 0.6em;
+    margin-bottom: 0.6em;
+  }
+`
+
+export default class Page extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      posts: [],
+      currentPosts: [],
+      contentCategories: [],
+      selectedCategories: [],
+    }
+
+    this.clickCategory = this.clickCategory.bind(this)
+    this.isHidden = this.isHidden.bind(this)
+  }
+
+  clickCategory(category) {
+    let selectedCategories = []
+
+    if (this.state.selectedCategories.includes(category)) {
+      selectedCategories = this.state.selectedCategories.filter(
+        cat => cat !== category
+      )
+    } else {
+      selectedCategories = [...this.state.selectedCategories, category]
+    }
+
+    this.setState({ selectedCategories })
+  }
+
+  isHidden(category) {
+    const currentPostsContentCategories = this.state.currentPosts.reduce(
+      (arr, post) => {
+        post.frontmatter.contentCategories.forEach(cat => {
+          if (!arr.includes(cat)) arr.push(cat)
+        })
+        return arr
+      },
+      []
+    )
+    return !currentPostsContentCategories.includes(category)
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    const { posts, contentCategories } = this.props
+
+    if (this.state.posts.length === 0) {
+      this.setState({ posts, contentCategories })
+      return
+    }
+
+    const currentPosts = this.state.posts.filter(post => {
+      return (
+        post.frontmatter.contentCategories.filter(cat =>
+          this.state.selectedCategories.includes(cat)
+        ).length === this.state.selectedCategories.length
+      )
+    })
+
+    if (currentPosts.length === this.state.currentPosts.length) return false
+
+    this.setState({ currentPosts })
+  }
+
+  render() {
+    return (
+      <Layout title="Element index">
+        <SEO title="Element index" />
+
+        <Container>
+          <Heading>Filtering</Heading>
+          <Ul>
+            {this.state.contentCategories.map((category, i) => {
+              return (
+                <li key={i}>
+                  <Button
+                    onClick={e => this.clickCategory(category)}
+                    isActive={this.state.selectedCategories.includes(category)}
+                    isHidden={this.isHidden(category)}
+                  >
+                    {category}
+                  </Button>
+                </li>
+              )
+            })}
+          </Ul>
+        </Container>
+
+        <Container>
+          <Heading>Elements</Heading>
+          <Elements
+            elements={this.state.posts}
+            currentElements={this.state.currentPosts.map(
+              p => p.frontmatter.title
+            )}
+          />
+        </Container>
+      </Layout>
+    )
+  }
+}

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -7,13 +7,11 @@ import Button from "../button"
 import Elements from "../elements"
 import SearchForm from "./search-form"
 
-const blue = `#1d2652`
-
 const Container = styled.div`
   position: relative;
   margin: 0 0 2rem;
   padding: 1.8em 1.4em 1.4em;
-  border: 1px dashed ${blue};
+  border: 1px dashed currentColor;
 `
 const Heading = styled.h2`
   position: absolute;
@@ -27,21 +25,12 @@ const Heading = styled.h2`
   font-size: 1rem;
   font-family: "Noto Sans JP", sans-serif;
   letter-spacing: 0.08em;
-  color: ${blue};
 `
 
-const _h = styled.h2`
-  font-weight: normal;
-  font-style: italic;
-  font-size: 1rem;
-  font-family: "Noto Sans JP", sans-serif;
-  letter-spacing: 0.08em;
-  color: ${blue};
-
-  &::before {
-    content: "-";
-    padding-right: 0.2em;
-  }
+const Hr = styled.hr`
+  margin: 1rem 0;
+  background-color: currentColor;
+  opacity: 0.5;
 `
 
 const Ul = styled.ul`
@@ -142,6 +131,7 @@ export default class Page extends React.Component {
               )
             })}
           </Ul>
+          <Hr />
           <SearchForm
             value={this.state.searchText}
             onInput={value => this.search(value)}

--- a/src/components/element/page.js
+++ b/src/components/element/page.js
@@ -53,7 +53,7 @@ export default class Page extends React.Component {
       currentPosts: [],
       contentCategories: [],
       selectedCategories: [],
-      searchText: 'bb',
+      searchText: '',
     }
 
     this.clickCategory = this.clickCategory.bind(this)

--- a/src/components/element/search-form.js
+++ b/src/components/element/search-form.js
@@ -1,0 +1,10 @@
+import React from "react"
+
+export default ({ onInput }) => {
+  function input(e) {
+    const value = e.target.value
+    onInput(value)
+  }
+
+  return <input type="text" onInput={e => input(e)} />
+}

--- a/src/components/element/search-form.js
+++ b/src/components/element/search-form.js
@@ -1,6 +1,22 @@
 import React from "react"
+import styled from "@emotion/styled"
+
+
+const Input = styled.input`
+  padding: 0.2em 0.6em;
+  color: inherit;
+  font-size: 0.9rem;
+  border: 1px solid currentColor;
+`
+
+const Label = styled.label`
+  font-size: 0.9rem;
+  margin-right: 1em;
+  color: currentColor;
+`
 
 export default ({ value, onInput }) => {
+
   function handleChange(e) {
     const value = e.target.value
     onInput(value)
@@ -8,8 +24,8 @@ export default ({ value, onInput }) => {
 
   return (
     <>
-      <label htmlFor="tagName">Tag Name</label>
-      <input
+      <Label htmlFor="tagName">Tag</Label>
+      <Input
         type="text"
         value={value}
         onChange={e => handleChange(e)}

--- a/src/components/element/search-form.js
+++ b/src/components/element/search-form.js
@@ -1,7 +1,7 @@
 import React from "react"
 
-export default ({ onInput }) => {
-  function input(e) {
+export default ({ value, onInput }) => {
+  function handleChange(e) {
     const value = e.target.value
     onInput(value)
   }
@@ -11,7 +11,8 @@ export default ({ onInput }) => {
       <label htmlFor="tagName">Tag Name</label>
       <input
         type="text"
-        onInput={e => input(e)}
+        value={value}
+        onChange={e => handleChange(e)}
         placeholder="ex. html"
         id="tagName"
       />

--- a/src/components/element/search-form.js
+++ b/src/components/element/search-form.js
@@ -6,5 +6,15 @@ export default ({ onInput }) => {
     onInput(value)
   }
 
-  return <input type="text" onInput={e => input(e)} />
+  return (
+    <>
+      <label htmlFor="tagName">Tag Name</label>
+      <input
+        type="text"
+        onInput={e => input(e)}
+        placeholder="ex. html"
+        id="tagName"
+      />
+    </>
+  )
 }

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -199,7 +199,7 @@ html {
   box-sizing: inherit;
 }
 body {
-  color: hsla(0, 0%, 0%, 0.8);
+  color: #1d2652;
   font-family: 'Noto Sans JP', sans-serif;
   font-weight: normal;
   word-wrap: break-word;
@@ -558,4 +558,9 @@ pre tt:after {
   html {
     font-size: 100%;
   }
+}
+::-webkit-input-placeholder {
+  color: currentColor;
+  font-size: 0.9em;
+  font-style: italic;
 }

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -1,76 +1,55 @@
 import React from "react"
 
-import { StaticQuery, graphql } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby"
 import Page from "../../components/element/page"
 
-class ElementList extends React.Component {
-  constructor() {
-    super()
-
-    this.state = {
-      posts: [],
-      currentPosts: [],
-    }
-  }
-
-  componentDidMount() {
-    const { data } = this.props
-    const { edges: _posts } = data.allMarkdownRemark
-    const posts = _posts.map(post => post.node)
-
-    const _fields = data.allAdminYaml.edges[0].node.collections[0].fields
-    const _contentCategoryOptions = _fields.filter(
-      field => field.name === "contentCategories"
-    )[0]
-    const contentCategories = _contentCategoryOptions.options.map(
-      option => option.label
-    )
-
-    this.setState({ posts, contentCategories })
-  }
-
-  render() {
-    return (
-      <Page
-        posts={this.state.posts}
-        contentCategories={this.state.contentCategories}
-      />
-    )
-  }
-}
-
-export default () => (
-  <StaticQuery
-    query={graphql`
-      {
-        allAdminYaml {
-          edges {
-            node {
-              collections {
-                fields {
-                  options {
-                    label
-                  }
-                  name
+export default () => {
+  const data = useStaticQuery(graphql`
+    {
+      allAdminYaml {
+        edges {
+          node {
+            collections {
+              fields {
+                options {
                   label
                 }
-              }
-            }
-          }
-        }
-        allMarkdownRemark(sort: { fields: frontmatter___order, order: ASC }) {
-          edges {
-            node {
-              frontmatter {
-                contentCategories
-                order
-                title
+                name
+                label
               }
             }
           }
         }
       }
-    `}
-    render={data => <ElementList data={data} />}
-  />
-)
+      allMarkdownRemark(sort: { fields: frontmatter___order, order: ASC }) {
+        edges {
+          node {
+            frontmatter {
+              contentCategories
+              order
+              title
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  const { edges: _posts } = data.allMarkdownRemark
+  const posts = _posts.map(post => post.node)
+
+  const _fields = data.allAdminYaml.edges[0].node.collections[0].fields
+  const _contentCategoryOptions = _fields.filter(
+    field => field.name === "contentCategories"
+  )[0]
+  const contentCategories = _contentCategoryOptions.options.map(
+    option => option.label
+  )
+
+  return (
+    <Page
+      posts={posts}
+      contentCategories={contentCategories}
+    />
+  )
+}

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -46,10 +46,5 @@ export default () => {
     option => option.label
   )
 
-  return (
-    <Page
-      posts={posts}
-      contentCategories={contentCategories}
-    />
-  )
+  return <Page posts={posts} contentCategories={contentCategories} />
 }

--- a/src/pages/element/index.js
+++ b/src/pages/element/index.js
@@ -1,84 +1,16 @@
 import React from "react"
-import styled from "@emotion/styled"
 
 import { StaticQuery, graphql } from "gatsby"
-import Layout from "../../components/layout"
-import SEO from "../../components/seo"
-import Button from "../../components/button"
-import Elements from "../../components/elements"
-
-const blue = `#1d2652`
-
-const Container = styled.div`
-  margin: 0 0 3rem;
-  padding: 1.4em;
-  border: 1px dashed ${blue};
-`
-const Heading = styled.h2`
-  font-weight: normal;
-  font-style: italic;
-  font-size: 1rem;
-  font-family: 'Noto Sans JP', sans-serif;
-  letter-spacing: 0.08em;
-  color: ${blue};
-
-  &::before {
-    content: "-";
-    padding-right: 0.2em;
-  }
-`
-
-const Ul = styled.ul`
-  display: flex;
-  flex-wrap: wrap;
-  list-style-type: none;
-  margin: 0 0 -0.6em;
-
-  li {
-    margin-right: 0.6em;
-    margin-bottom: 0.6em;
-  }
-`
+import Page from "../../components/element/page"
 
 class ElementList extends React.Component {
   constructor() {
     super()
+
     this.state = {
       posts: [],
       currentPosts: [],
-      contentCategories: [],
-      selectedCategories: [],
     }
-
-    this.clickCategory = this.clickCategory.bind(this)
-    this.isHidden = this.isHidden.bind(this)
-  }
-
-  clickCategory(category) {
-    let selectedCategories = []
-
-    if (this.state.selectedCategories.includes(category)) {
-      selectedCategories = this.state.selectedCategories.filter(
-        cat => cat !== category
-      )
-    } else {
-      selectedCategories = [...this.state.selectedCategories, category]
-    }
-
-    this.setState({ selectedCategories })
-  }
-
-  isHidden(category) {
-    const currentPostsContentCategories = this.state.currentPosts.reduce(
-      (arr, post) => {
-        post.frontmatter.contentCategories.forEach(cat => {
-          if (!arr.includes(cat)) arr.push(cat)
-        })
-        return arr
-      },
-      []
-    )
-    return !currentPostsContentCategories.includes(category)
   }
 
   componentDidMount() {
@@ -94,57 +26,15 @@ class ElementList extends React.Component {
       option => option.label
     )
 
-    this.setState({ posts, contentCategories, currentPosts: posts })
-  }
-
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    const currentPosts = this.state.posts.filter(post => {
-      return (
-        post.frontmatter.contentCategories.filter(cat =>
-          this.state.selectedCategories.includes(cat)
-        ).length === this.state.selectedCategories.length
-      )
-    })
-
-    if (currentPosts.length === this.state.currentPosts.length) return false
-
-    this.setState({ currentPosts })
+    this.setState({ posts, contentCategories })
   }
 
   render() {
     return (
-      <Layout title="Element index">
-        <SEO title="Element index" />
-
-        <Container>
-          <Heading>Filtering</Heading>
-          <Ul>
-            {this.state.contentCategories.map((category, i) => {
-              return (
-                <li key={i}>
-                  <Button
-                    onClick={e => this.clickCategory(category)}
-                    isActive={this.state.selectedCategories.includes(category)}
-                    isHidden={this.isHidden(category)}
-                  >
-                    {category}
-                  </Button>
-                </li>
-              )
-            })}
-          </Ul>
-        </Container>
-
-        <Container>
-          <Heading>Elements</Heading>
-          <Elements
-            elements={this.state.posts}
-            currentElements={this.state.currentPosts.map(
-              p => p.frontmatter.title
-            )}
-          />
-        </Container>
-      </Layout>
+      <Page
+        posts={this.state.posts}
+        contentCategories={this.state.contentCategories}
+      />
     )
   }
 }

--- a/src/templates/element.js
+++ b/src/templates/element.js
@@ -4,11 +4,11 @@ import { graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { FaLink } from 'react-icons/fa';
+import { FaLink } from "react-icons/fa"
 
-const mdnUrl = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element";
-const whatwgUrl = `https://html.spec.whatwg.org/multipage/semantics.html`;
-const linkColor = `#063173`;
+const mdnUrl = "https://developer.mozilla.org/en-US/docs/Web/HTML/Element"
+const whatwgUrl = `https://html.spec.whatwg.org/multipage/semantics.html`
+const linkColor = `#063173`
 
 const A = styled.a`
   color: ${linkColor};
@@ -16,7 +16,7 @@ const A = styled.a`
   position: relative;
 
   &::before {
-    content: '';
+    content: "";
     position: absolute;
     top: calc(100% + 4px);
     left: 0;
@@ -43,7 +43,7 @@ const Li = styled.li`
   padding-left: 1rem;
 
   &::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 50%;
     left: 0;
@@ -60,7 +60,7 @@ export default ({ data }) => {
 
   const links = [
     { title: `MDN web docs`, url: `${mdnUrl}/${title}` },
-    { title: `HTML Living Standard`, url: `${whatwgUrl}#the-${title}-element` }
+    { title: `HTML Living Standard`, url: `${whatwgUrl}#the-${title}-element` },
   ]
 
   return (


### PR DESCRIPTION
## Summary

HTML のタグをタグ名でフィルタリングできるようにしました。

## TODO

- [x] Add search input form
- [x] Separate each component
- [x] Styling

## Supplement

フォームの中身が増えてきて縦に膨らんできたので、見出しがコンパクトに収まるデザインに修正しました。

### before
![スクリーンショット 2020-01-07 16 30 48](https://user-images.githubusercontent.com/5207601/71876866-23329280-316b-11ea-8b59-09dc6692ef2e.png)

### after
![スクリーンショット 2020-01-07 16 30 56](https://user-images.githubusercontent.com/5207601/71876872-26c61980-316b-11ea-8b31-4259a3038a4b.png)



## Operation Verification
デプロイプレビューで、input に `html` と入力して html 要素だけがハイライトされること。
https://deploy-preview-11--html-shgtkshruch.netlify.com/element/